### PR TITLE
Changed Syntax for Skeleton App

### DIFF
--- a/docs/book/getting-started/skeleton-application.md
+++ b/docs/book/getting-started/skeleton-application.md
@@ -6,7 +6,7 @@ available on [GitHub](https://github.com/). Use [Composer](https://getcomposer.o
 to create a new project from scratch:
 
 ```bash
-$ composer create-project -s dev laminas/laminas-mvc-skeleton path/to/install
+$ composer create-project -sdev laminas/laminas-mvc-skeleton path/to/install
 ```
 
 This will install an initial set of dependencies, including:


### PR DESCRIPTION
Original instruction: `composer create-project -s dev laminas/laminas-mvc-skeleton path/to/install` doesn't work.  Removed the space between `-s` and `dev`.  Works OK.  New instruction:
`composer create-project -sdev laminas/laminas-mvc-skeleton path/to/install`

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Original instruction: `composer create-project -s dev laminas/laminas-mvc-skeleton path/to/install` doesn't work.  Removed the space between `-s` and `dev`.  Works OK.  New instruction:
`composer create-project -sdev laminas/laminas-mvc-skeleton path/to/install`
