### PR TITLE
Update routing-and-controllers.md

### DIFF
--- a/docs/book/getting-started/routing-and-controllers.md
+++ b/docs/book/getting-started/routing-and-controllers.md
@@ -50,7 +50,7 @@ return [
     'router' => [
         'routes' => [
             'album' => [
-                'type'    => Segment::class,
+                'type'    => \Segment::class,
                 'options' => [
                     'route' => '/album[/:action[/:id]]',
                     'constraints' => [


### PR DESCRIPTION
Fixed namespace error for Segment class in line 53 by adding backslash

<!--
Fill in the relevant information below to help triage your issue.

-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

There was missing a backslash in module.config.php for Segement class
