### PR TITLE
"route config fix - prevent missing parameter "id" in laminas/laminas…

### DIFF
--- a/docs/book/in-depth-guide/data-binding.md
+++ b/docs/book/in-depth-guide/data-binding.md
@@ -205,7 +205,7 @@ return [
                     'edit' => [
                         'type' => Segment::class,
                         'options' => [
-                            'route'    => '/edit/:id',
+                            'route'    => '/edit[/:id]',
                             'defaults' => [
                                 'controller' => Controller\WriteController::class,
                                 'action'     => 'edit',


### PR DESCRIPTION
…-router/src/Http/Segment.php:310"

Signed-off-by: pilleck <pilleck@cineamo.com>


|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description


- I think I fix a bug when newbies like me try to follow the lamians tutorial
- I can redproduce the route error following the tutorial as it is now