### PR TITLE
[Form and Actions] Add try catch in editAction() on saveAlbum() for Album module

### DIFF
--- a/docs/book/getting-started/forms-and-actions.md
+++ b/docs/book/getting-started/forms-and-actions.md
@@ -450,7 +450,11 @@ This time we use `editAction()` in the `AlbumController`:
             return $viewData;
         }
 
-        $this->table->saveAlbum($album);
+        try {
+            $this->table->saveAlbum($album);
+        } catch (\Exception $e) {
+            return $this->redirect()->toRoute('album', ['action' => 'index']);
+        }
 
         // Redirect to album list
         return $this->redirect()->toRoute('album', ['action' => 'index']);

--- a/docs/book/getting-started/forms-and-actions.md
+++ b/docs/book/getting-started/forms-and-actions.md
@@ -453,7 +453,6 @@ This time we use `editAction()` in the `AlbumController`:
         try {
             $this->table->saveAlbum($album);
         } catch (\Exception $e) {
-            return $this->redirect()->toRoute('album', ['action' => 'index']);
         }
 
         // Redirect to album list


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

To handle form hidden id edited via browser developer tool, and click save. Previous try catch is only handle on `/id` part.